### PR TITLE
fix(connector): JS-parity session/machine-id (0.4.1-preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ notes, and the detailed changelog - are the single source of truth in
 [src/StpSDK.JsonRpc/Docs/ReleaseNotes.md](src/StpSDK.JsonRpc/Docs/ReleaseNotes.md),
 which also feeds the NuGet package release notes.
 
+## 0.4.1-preview
+- Connector fix: dropped the MAC-based machine id (OAA carryover that yielded an empty session on machines whose first NIC has no MAC); use a random id and STP's Register-assigned session, matching the JS SDK
+- Added live parity smoke tests (structured SIDC, rendering, add/update/delete) against a running engine
+
 ## 0.4.0-preview
 - Migrated to the JSON-RPC / WebSocket transport (replaces the OAA / Prolog protocol)
 - SDK relocated to this repository and published as the canonical `HyssosTech.Sdk.STP` package

--- a/src/StpSDK.JsonRpc/Docs/ReleaseNotes.md
+++ b/src/StpSDK.JsonRpc/Docs/ReleaseNotes.md
@@ -5,6 +5,34 @@ The Sketch-Thru-Plan (STP) .NET SDK is published to NuGet as
 for the SDK; notable changes to the accompanying samples, quickstart, and
 plugins are folded in under the relevant versions.
 
+## Version 0.4.1-preview
+
+### Summary
+
+This build supports:
+
+- **Connection fix**: the connector no longer derives a machine id from a NIC MAC address (an OAA-SDK carryover that returned an empty id - and thus an empty session - on machines whose first adapter has no MAC). It now uses a random id when none is supplied and treats the session id returned by STP's Register as authoritative, matching the JavaScript SDK.
+
+### Notes
+
+**Connection / session handling aligned with the JS SDK**
+
+The previous build computed a machine id from the first network adapter's physical
+(MAC) address. On many machines the first adapter is a loopback/virtual one with no
+MAC, so the id - and the resulting session id - came back empty and registration
+failed. The JSON-RPC SDK has no notion of a physical machine identity (the JS SDK
+uses a random id); STP assigns/normalizes the session and returns it from Register.
+The connector now mirrors that: a random id is used when `machineId` is not provided,
+and the session id from the Register response is authoritative. To join a specific
+session, pass an explicit `sessionId` (or machineId) to `ConnectAndRegisterAsync`.
+
+### Changelog
+
++ Fixes
+	- Connector: replaced the MAC-based machine id with a random id; use the STP-assigned session id from the Register response (fixes empty-session registration failures; matches the JS SDK)
++ Improvements
+	- Added live parity smoke tests (structured SIDC, JMSML rendering, add/update/delete lifecycle) exercised against a running engine
+
 ## Version 0.4.0-preview
 
 ### Summary

--- a/src/StpSDK.JsonRpc/StpSDK.csproj
+++ b/src/StpSDK.JsonRpc/StpSDK.csproj
@@ -61,7 +61,7 @@
   <!-- NuGet package metadata -->
   <PropertyGroup>
     <PackageId>HyssosTech.Sdk.STP</PackageId>
-    <Version>0.4.0-preview</Version>
+    <Version>0.4.1-preview</Version>
     <Authors>Hyssos Tech</Authors>
     <Company>Hyssos Tech</Company>
     <Description>Hyssos Sketch-Thru-Plan .NET SDK - JSON-RPC client for the STP natural-language map planning engine.</Description>

--- a/src/StpSDK.JsonRpc/Transport/StpJsonRpcConnector.cs
+++ b/src/StpSDK.JsonRpc/Transport/StpJsonRpcConnector.cs
@@ -104,7 +104,7 @@ public class StpJsonRpcConnector : IStpConnector
     public async Task<string> RegisterAsync(string serviceName, List<string> solvables, string machineId = null, string sessionId = null, CancellationToken ct = default)
     {
         _serviceName = serviceName;
-        _machineId = machineId ?? GetDefaultMachineId();
+        _machineId = machineId ?? GetUniqueId();
         _sessionId = sessionId ?? _machineId;
 
         var registerMsg = new JsonRpcMessage
@@ -127,6 +127,10 @@ public class StpJsonRpcConnector : IStpConnector
             30000,
             ct).ConfigureAwait(false);
 
+        // STP returns the session id it actually used (it may assign/normalize a default),
+        // mirroring the JS SDK which treats the Register response as authoritative.
+        if (!string.IsNullOrEmpty(result))
+            _sessionId = result;
         return _sessionId;
     }
 
@@ -231,16 +235,13 @@ public class StpJsonRpcConnector : IStpConnector
         _pendingRequests.Clear();
     }
 
-    private static string GetDefaultMachineId()
+    // The JSON-RPC SDK has no physical machine identity (unlike the OAA SDK, which keyed
+    // per-machine sessions off a NIC MAC). Mirror the JS SDK: when no machineId is supplied
+    // use a short random id; STP assigns/normalizes the session and returns it from Register.
+    private static string GetUniqueId(int numChars = 9)
     {
-        try
-        {
-            var nic = NetworkInterface.GetAllNetworkInterfaces();
-            if (nic.Length > 0)
-                return nic[0].GetPhysicalAddress().ToString();
-        }
-        catch { }
-        return Environment.MachineName;
+        string id = Guid.NewGuid().ToString("N");
+        return numChars > 0 && numChars < id.Length ? id.Substring(0, numChars) : id;
     }
 
     public void Dispose()

--- a/tests/StpSDK.Tests/LiveParitySmokeTests.cs
+++ b/tests/StpSDK.Tests/LiveParitySmokeTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace StpSDK.Tests;
+
+/// <summary>
+/// Live smoke tests exercised against a running STP engine (ws://localhost:9599) to
+/// validate end-to-end parity with the JS SDK and the engine wire format - especially
+/// the structured <see cref="Sidc"/> (the engine sends partA/partB/symbolSet/legacy)
+/// and JMSML rendering. Category "SmokeTest" is excluded from CI; run explicitly with
+/// a live engine: dotnet test --filter Category=SmokeTest
+/// </summary>
+[TestFixture]
+[Category("SmokeTest")]
+public class LiveParitySmokeTests
+{
+    private const int ConnectTimeoutSec = 15;
+    private const int EventWaitMs = 30_000;
+    private const string SvgPath = @"C:\ProgramData\STP\JMS\svg";
+
+    // Map extent used for placing point symbols (Bogoland scenario area).
+    private static readonly LatLon TopLeft = new(59.27, 9.70);
+    private static readonly LatLon BotRight = new(59.01, 10.44);
+    private static readonly LatLon Center = new(59.14, 10.07);
+
+    private static StpSymbol MakeUnit(string sidc, Affiliation aff, string designator = null) => new()
+    {
+        Type = "unit",
+        SymbolId = sidc,                 // 2525C/legacy code; stored on Sidc.Legacy
+        Affiliation = aff,
+        Designator1 = designator,
+        Location = new Location
+        {
+            Type = "point",
+            Shape = "point",
+            Coords = new List<LatLon> { Center },
+            Centroid = Center
+        },
+        Geometry = "point"
+    };
+
+    private static async Task<StpRecognizer> ConnectAsync(string agent, params Action<StpRecognizer>[] hooks)
+    {
+        var connector = new StpJsonRpcConnector();
+        var recognizer = new StpRecognizer(connector);
+        recognizer.OnStpMessage += (level, msg) => TestContext.Out.WriteLine($"[STP {level}] {msg}");
+        foreach (var h in hooks) h(recognizer);
+        string session = await recognizer.ConnectAndRegisterAsync(agent, secondsToRetry: ConnectTimeoutSec);
+        Assert.That(session, Is.Not.Null.And.Not.Empty, "connect+register should return a session id");
+        Assert.That(recognizer.IsConnected, Is.True);
+        recognizer.AdvertiseViewport(TopLeft, BotRight);
+        return recognizer;
+    }
+
+    /// <summary>
+    /// Core parity check: a placed unit comes back with a fully populated structured SIDC
+    /// (2525C legacy + 2525D delta/parts + symbol set) and renders via JMSML.
+    /// </summary>
+    [Test]
+    public async Task AddUnit_ReturnsStructuredSidc_AndRenders()
+    {
+        StpSymbol received = null;
+        var added = new ManualResetEventSlim(false);
+
+        using var recognizer = await ConnectAsync("ParitySmoke_Add",
+            r => r.OnSymbolAdded += (poid, item, isUndo) =>
+            {
+                if (item is StpSymbol s && s.Type == "unit") { received = s; added.Set(); }
+            });
+
+        recognizer.AddSymbol(MakeUnit("SFGPUCI----E---", Affiliation.friend));   // friendly infantry company
+
+        Assert.That(added.Wait(EventWaitMs), Is.True, "OnSymbolAdded should fire for the placed unit");
+        Assert.That(received, Is.Not.Null);
+
+        // --- structured SIDC parity (engine -> SDK) ---
+        Assert.That(received.Sidc, Is.Not.Null, "engine must deliver a structured sidc object");
+        TestContext.Out.WriteLine($"poid={received.Poid}");
+        TestContext.Out.WriteLine($"CharlieSIDC(legacy)={received.CharlieSIDC}  DeltaSIDC={received.DeltaSIDC}  SymbolSet={received.SymbolSet}");
+        TestContext.Out.WriteLine($"partA={received.Sidc.PartA} partB={received.Sidc.PartB}");
+        TestContext.Out.WriteLine($"affiliation={received.Affiliation} desc=\"{received.Description}\" full=\"{received.FullDescription}\"");
+
+        Assert.That(received.CharlieSIDC, Is.Not.Null.And.Not.Empty, "2525C legacy code should be present");
+        Assert.That(received.DeltaSIDC, Is.Not.Null.And.Not.Empty, "2525D delta (partA+partB) should be reconstructed from engine parts");
+        Assert.That(received.Sidc.PartA, Is.Not.Null.And.Not.Empty, "partA should be derivable from delta");
+        Assert.That(received.SymbolSet, Is.Not.Null.And.Not.Empty, "2525D symbol set should be present");
+        Assert.That(received.Affiliation, Is.EqualTo(Affiliation.friend));
+        Assert.That(received.FullDescription, Is.Not.Null.And.Not.Empty, "engine should supply a (full) description");
+
+        // --- JMSML rendering (Windows + SVG set) ---
+        StpRecognizer.JMSSVGPath = SvgPath;
+        Bitmap bmp = received.Bitmap(64, 64);
+        if (OperatingSystem.IsWindows() && Directory.Exists(SvgPath))
+        {
+            Assert.That(bmp, Is.Not.Null, "JMSML should render the engine-supplied symbol");
+            Assert.That(bmp!.Width, Is.GreaterThan(0));
+            TestContext.Out.WriteLine($"rendered bitmap {bmp.Width}x{bmp.Height}");
+        }
+        else
+        {
+            TestContext.Out.WriteLine($"render skipped (Windows+SVG set unavailable); Bitmap returned {(bmp is null ? "null" : "a bitmap")}");
+        }
+
+        recognizer.Stop();
+    }
+
+    /// <summary>
+    /// Full lifecycle: add a unit, update it, delete it - confirming the corresponding
+    /// events round-trip against the live engine.
+    /// </summary>
+    [Test]
+    public async Task Symbol_Lifecycle_Add_Update_Delete()
+    {
+        string addedPoid = null;
+        var added = new ManualResetEventSlim(false);
+        var modified = new ManualResetEventSlim(false);
+        var deleted = new ManualResetEventSlim(false);
+
+        using var recognizer = await ConnectAsync("ParitySmoke_Lifecycle",
+            r =>
+            {
+                r.OnSymbolAdded += (poid, item, isUndo) =>
+                {
+                    if (addedPoid is null && item is StpSymbol s && s.Type == "unit") { addedPoid = poid; added.Set(); }
+                };
+                r.OnSymbolModified += (poid, item, isUndo) => { if (poid == addedPoid) modified.Set(); };
+                r.OnSymbolDeleted += (poid, isUndo) => { if (poid == addedPoid) deleted.Set(); };
+            });
+
+        recognizer.AddSymbol(MakeUnit("SFGPUCI----E---", Affiliation.friend, "A1"));   // friendly infantry company (known-good)
+        Assert.That(added.Wait(EventWaitMs), Is.True, "OnSymbolAdded should fire");
+        Assert.That(addedPoid, Is.Not.Null.And.Not.Empty);
+        TestContext.Out.WriteLine($"added poid={addedPoid}");
+
+        // Update: move the symbol and change its designator.
+        var update = MakeUnit("SFGPUCI----E---", Affiliation.friend, "A2");
+        update.Poid = addedPoid;
+        update.Location.Coords = new List<LatLon> { new(59.10, 10.20) };
+        update.Location.Centroid = new(59.10, 10.20);
+        recognizer.UpdateSymbol(addedPoid, update);
+        bool gotModified = modified.Wait(10_000);   // best-effort: engine may not re-emit for every update
+        TestContext.Out.WriteLine($"OnSymbolModified fired: {gotModified}");
+
+        recognizer.DeleteSymbol(addedPoid);
+        Assert.That(deleted.Wait(EventWaitMs), Is.True, "OnSymbolDeleted should fire after DeleteSymbol");
+        TestContext.Out.WriteLine($"OnSymbolDeleted fired for {addedPoid}");
+
+        recognizer.Stop();
+    }
+}


### PR DESCRIPTION
Found via live smoke testing: the connector carried two OAA-SDK artifacts that don't belong in the JSON-RPC SDK and diverge from the JS SDK.

- **MAC-based machine id** (`GetDefaultMachineId` -> `nic[0].GetPhysicalAddress()`): on machines whose first adapter has no MAC (loopback/virtual) this returns an empty id -> empty session -> registration fails. Replaced with a random id (`GetUniqueId`), matching the JS SDK (`getUniqueId(9)`).
- **Ignored STP's session**: `RegisterAsync` discarded the Register response and returned the local guess. It now returns the session id STP assigns/echoes (authoritative), like the JS SDK (`this.sessionId = await this.register()`).

To join a specific session, pass an explicit `sessionId`/`machineId`; otherwise a unique session is used (engine-assigned), as in JS.

Also adds live parity smoke tests (Category=SmokeTest, excluded from CI) validated against a running engine: connect/register, structured SIDC (Charlie/Delta/SymbolSet from real engine messages), JMSML rendering, and the add/update/delete lifecycle.

Bumps to 0.4.1-preview. Note: the published 0.4.0-preview has the MAC bug and should be superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)