### PR TITLE
fix(connector): proper stable machine id (mirror engine Auth.GetMachineID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ notes, and the detailed changelog - are the single source of truth in
 which also feeds the NuGet package release notes.
 
 ## 0.4.1-preview
-- Connector fix: dropped the MAC-based machine id (OAA carryover that yielded an empty session on machines whose first NIC has no MAC); use a random id and STP's Register-assigned session, matching the JS SDK
+- Connector fix: compute a stable machine id like the STP engine (highest non-empty NIC MAC; host-name fallback) instead of the first adapter's MAC, which was often empty -> empty session -> failed registration
+- Connector fix: use the STP-assigned session id from the Register response (was discarded)
 - Added live parity smoke tests (structured SIDC, rendering, add/update/delete) against a running engine
 
 ## 0.4.0-preview

--- a/src/StpSDK.JsonRpc/Docs/ReleaseNotes.md
+++ b/src/StpSDK.JsonRpc/Docs/ReleaseNotes.md
@@ -11,25 +11,32 @@ plugins are folded in under the relevant versions.
 
 This build supports:
 
-- **Connection fix**: the connector no longer derives a machine id from a NIC MAC address (an OAA-SDK carryover that returned an empty id - and thus an empty session - on machines whose first adapter has no MAC). It now uses a random id when none is supplied and treats the session id returned by STP's Register as authoritative, matching the JavaScript SDK.
+- **Connection fix**: corrected machine-id and session handling in the connector - two regressions from the OAA-to-JSON-RPC port that broke registration.
 
 ### Notes
 
-**Connection / session handling aligned with the JS SDK**
+**Machine id computed correctly**
 
-The previous build computed a machine id from the first network adapter's physical
-(MAC) address. On many machines the first adapter is a loopback/virtual one with no
-MAC, so the id - and the resulting session id - came back empty and registration
-failed. The JSON-RPC SDK has no notion of a physical machine identity (the JS SDK
-uses a random id); STP assigns/normalizes the session and returns it from Register.
-The connector now mirrors that: a random id is used when `machineId` is not provided,
-and the session id from the Register response is authoritative. To join a specific
-session, pass an explicit `sessionId` (or machineId) to `ConnectAndRegisterAsync`.
+The connector derived the machine id from the *first* network adapter's MAC, but that
+adapter is frequently a loopback/virtual one with no MAC - yielding an empty id and an
+empty session, so registration failed. It now computes a stable machine id the same way
+the STP engine does (`Auth.GetMachineID`: the highest non-empty NIC MAC, formatted
+`XX-XX-...`, with a host-name fallback), so .NET clients on the same host - OAA or
+JSON-RPC - share the default per-machine session. (A browser can't read a MAC, so the
+JS SDK uses a random id; .NET can and does compute a real one.)
+
+**STP-assigned session is authoritative**
+
+Registration previously discarded the session id returned by STP and returned its own
+local value. It now returns the session id from the Register response (STP may
+assign/normalize a default), matching the JS SDK. Pass an explicit `sessionId` to
+`ConnectAndRegisterAsync` to join a specific session.
 
 ### Changelog
 
 + Fixes
-	- Connector: replaced the MAC-based machine id with a random id; use the STP-assigned session id from the Register response (fixes empty-session registration failures; matches the JS SDK)
+	- Connector: compute a stable machine id like the engine (highest non-empty NIC MAC; host-name fallback) instead of the first adapter's MAC - fixes empty-session registration failures
+	- Connector: use the STP-assigned session id from the Register response (it was being discarded)
 + Improvements
 	- Added live parity smoke tests (structured SIDC, JMSML rendering, add/update/delete lifecycle) exercised against a running engine
 

--- a/src/StpSDK.JsonRpc/Transport/StpJsonRpcConnector.cs
+++ b/src/StpSDK.JsonRpc/Transport/StpJsonRpcConnector.cs
@@ -4,7 +4,9 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.NetworkInformation;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
@@ -104,7 +106,7 @@ public class StpJsonRpcConnector : IStpConnector
     public async Task<string> RegisterAsync(string serviceName, List<string> solvables, string machineId = null, string sessionId = null, CancellationToken ct = default)
     {
         _serviceName = serviceName;
-        _machineId = machineId ?? GetUniqueId();
+        _machineId = machineId ?? GetDefaultMachineId();
         _sessionId = sessionId ?? _machineId;
 
         var registerMsg = new JsonRpcMessage
@@ -235,13 +237,41 @@ public class StpJsonRpcConnector : IStpConnector
         _pendingRequests.Clear();
     }
 
-    // The JSON-RPC SDK has no physical machine identity (unlike the OAA SDK, which keyed
-    // per-machine sessions off a NIC MAC). Mirror the JS SDK: when no machineId is supplied
-    // use a short random id; STP assigns/normalizes the session and returns it from Register.
-    private static string GetUniqueId(int numChars = 9)
+    private static string _cachedMachineId;
+
+    /// <summary>
+    /// Stable machine identifier used to key the default per-machine session. Mirrors the
+    /// STP engine's <c>Auth.GetMachineID()</c> so .NET clients on the same host (OAA or
+    /// JSON-RPC) agree on the session: the highest non-empty NIC MAC, formatted as
+    /// upper-case <c>XX-XX-...</c>, falling back to the host name. (Unlike the JS SDK, which
+    /// can't read a MAC in the browser sandbox and uses a random id, .NET can and should.)
+    /// </summary>
+    private static string GetDefaultMachineId()
     {
-        string id = Guid.NewGuid().ToString("N");
-        return numChars > 0 && numChars < id.Length ? id.Substring(0, numChars) : id;
+        if (_cachedMachineId is not null)
+            return _cachedMachineId;
+        try
+        {
+            foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                byte[] bytes = nic.GetPhysicalAddress()?.GetAddressBytes();
+                if (bytes is null || bytes.Length == 0)        // skip loopback/virtual adapters with no MAC
+                    continue;
+                var sb = new StringBuilder(bytes.Length * 3);
+                for (int i = 0; i < bytes.Length; i++)
+                    sb.AppendFormat("{0:X2}{1}", bytes[i], i < bytes.Length - 1 ? "-" : "");
+                string mac = sb.ToString();
+                if (mac.CompareTo(_cachedMachineId) > 0)       // largest MAC wins (stable across adapters)
+                    _cachedMachineId = mac;
+            }
+            if (string.IsNullOrEmpty(_cachedMachineId))
+                _cachedMachineId = Dns.GetHostName().ToUpperInvariant();
+        }
+        catch
+        {
+            _cachedMachineId = Dns.GetHostName().ToUpperInvariant();
+        }
+        return _cachedMachineId;
     }
 
     public void Dispose()

--- a/tests/StpSDK.Tests/LiveParitySmokeTests.cs
+++ b/tests/StpSDK.Tests/LiveParitySmokeTests.cs
@@ -50,8 +50,11 @@ public class LiveParitySmokeTests
         var recognizer = new StpRecognizer(connector);
         recognizer.OnStpMessage += (level, msg) => TestContext.Out.WriteLine($"[STP {level}] {msg}");
         foreach (var h in hooks) h(recognizer);
-        string session = await recognizer.ConnectAndRegisterAsync(agent, secondsToRetry: ConnectTimeoutSec);
-        Assert.That(session, Is.Not.Null.And.Not.Empty, "connect+register should return a session id");
+        // Unique session per test for isolation. (The default no-session / machine-id path
+        // is validated separately by JsonRpcIntegrationSmokeTests.Agent_ConnectAndRegister_Succeeds.)
+        string session = "smoke-" + Guid.NewGuid().ToString("N").Substring(0, 12);
+        string assigned = await recognizer.ConnectAndRegisterAsync(agent, session: session, secondsToRetry: ConnectTimeoutSec);
+        Assert.That(assigned, Is.Not.Null.And.Not.Empty, "connect+register should return a session id");
         Assert.That(recognizer.IsConnected, Is.True);
         recognizer.AdvertiseViewport(TopLeft, BotRight);
         return recognizer;
@@ -143,8 +146,8 @@ public class LiveParitySmokeTests
         update.Location.Coords = new List<LatLon> { new(59.10, 10.20) };
         update.Location.Centroid = new(59.10, 10.20);
         recognizer.UpdateSymbol(addedPoid, update);
-        bool gotModified = modified.Wait(10_000);   // best-effort: engine may not re-emit for every update
-        TestContext.Out.WriteLine($"OnSymbolModified fired: {gotModified}");
+        Assert.That(modified.Wait(EventWaitMs), Is.True, "OnSymbolModified should fire after UpdateSymbol");
+        TestContext.Out.WriteLine($"OnSymbolModified fired for {addedPoid}");
 
         recognizer.DeleteSymbol(addedPoid);
         Assert.That(deleted.Wait(EventWaitMs), Is.True, "OnSymbolDeleted should fire after DeleteSymbol");


### PR DESCRIPTION
Follow-up to #4. Per review: .NET can and should compute a real machine id (a browser can't, so the JS SDK uses a random one). Replaces the interim random id with the engine's algorithm so .NET clients on the same host - OAA or JSON-RPC - share the default per-machine session.

- `GetDefaultMachineId` now mirrors STP `Auth.GetMachineID`: highest non-empty NIC MAC, formatted `XX-XX-...`, host-name fallback; skips loopback/virtual adapters with no MAC (the original empty-session bug).
- Register response remains authoritative for the session id (the discard bug stays fixed).
- Live parity smoke tests isolate per test (explicit session) and now **require** `OnSymbolModified` and `OnSymbolDeleted` - both fire against the live engine.

Validated: 309 unit/rendering tests pass; all 4 live SmokeTests pass (connect/register, structured SIDC, JMSML rendering, add/update/delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)